### PR TITLE
Implemented in-game push to talk

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -31,6 +31,7 @@ DEEPL_AUTH_KEY=
 # Key to hold down when speaking, e.g v, e
 MIC_RECORD_KEY=f
 # If this is set, the script will hold down this key while playing audio.
+# For apps like Valorant with no Open Mic functionality, must be different from MIC_RECORD_KEY
 INGAME_PUSH_TO_TALK_KEY=
 
 ### AUDIO DEVICE IDS ###

--- a/.env.sample
+++ b/.env.sample
@@ -30,7 +30,8 @@ DEEPL_AUTH_KEY=
 ### PUSH TO TALK KEY ###
 # Key to hold down when speaking, e.g v, e
 MIC_RECORD_KEY=f
-
+# If this is set, the script will hold down this key while playing audio.
+INGAME_PUSH_TO_TALK_KEY=
 
 ### AUDIO DEVICE IDS ###
 

--- a/src/modules/voicevox.py
+++ b/src/modules/voicevox.py
@@ -31,11 +31,14 @@ VOICEVOX_WAV_PATH = Path(__file__).resolve().parent.parent / r'audio\voicevox.wa
 
 def play_voice(device_id):
     data, fs = sf.read(VOICEVOX_WAV_PATH, dtype='float32')
-    if (INGAME_PUSH_TO_TALK_KEY != '') :
+
+    if INGAME_PUSH_TO_TALK_KEY:
         keyboard.press(INGAME_PUSH_TO_TALK_KEY)
+
     sd.play(data, fs, device=device_id)
     sd.wait()
-    if (INGAME_PUSH_TO_TALK_KEY != '') :
+
+    if INGAME_PUSH_TO_TALK_KEY:
         keyboard.release(INGAME_PUSH_TO_TALK_KEY)
 
 

--- a/src/modules/voicevox.py
+++ b/src/modules/voicevox.py
@@ -7,12 +7,16 @@ import requests
 import sounddevice as sd
 import soundfile as sf
 from dotenv import load_dotenv
+import keyboard
 
 load_dotenv()
 
 # Audio devices
 SPEAKERS_INPUT_ID = int(getenv('VOICEMEETER_INPUT_ID'))
 APP_INPUT_ID = int(getenv('CABLE_INPUT_ID'))
+
+# Keyboard
+INGAME_PUSH_TO_TALK_KEY = getenv('INGAME_PUSH_TO_TALK_KEY')
 
 # Voicevox settings
 BASE_URL = getenv('VOICEVOX_BASE_URL')
@@ -27,8 +31,12 @@ VOICEVOX_WAV_PATH = Path(__file__).resolve().parent.parent / r'audio\voicevox.wa
 
 def play_voice(device_id):
     data, fs = sf.read(VOICEVOX_WAV_PATH, dtype='float32')
+    if (INGAME_PUSH_TO_TALK_KEY != '') :
+        keyboard.press(INGAME_PUSH_TO_TALK_KEY)
     sd.play(data, fs, device=device_id)
     sd.wait()
+    if (INGAME_PUSH_TO_TALK_KEY != '') :
+        keyboard.release(INGAME_PUSH_TO_TALK_KEY)
 
 
 def speak_jp(sentence):


### PR DESCRIPTION
This is the implementation for #37, It allows users to use this tool with applications that force push to talk (Valorant). Users can set their in-game push to talk button in the .env file. The script will then hold the button while outputting audio.
Tested by running voicevox.py, the player icon shows up during audio playback.
![image](https://user-images.githubusercontent.com/24196833/224505168-7f5bea60-7d46-4e0d-98dc-15e101e01956.png)
